### PR TITLE
Sets autoDeploy to false

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,6 +5,7 @@ services:
     plan: standard
     # Recommended health check endpoint: https://matomo.org/faq/how-to/faq_20278/
     healthCheckPath: /matomo.php
+    autoDeploy: false
     disk:
       name: matomo
       mountPath: /var/www/html
@@ -36,6 +37,7 @@ services:
     repo: https://github.com/render-examples/mysql.git
     env: docker
     plan: standard
+    autoDeploy: false
     disk:
       name: mysql-matomo
       mountPath: /var/lib/mysql


### PR DESCRIPTION
By setting `autoDeploy: false` in the the `render.yaml`, we can ensure that subsequent merges to the main branch of this repository will not trigger deploys for any instances that have been created and deployed by the Deploy to Render button.

However, merging this PR will trigger a final forced deployment of any instances created and deployed by the Deploy to Render button.

See [the Render docs](https://render.com/docs/deploy-to-render) for more information.

Signed-off-by: zach wick <zach@render.com>